### PR TITLE
Add edit feature, closes #7

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -9,6 +9,7 @@ const Router = Ember.Router.extend({
 Router.map(function() {
   this.route('reminders', { path: '/' }, function() {
     this.route('reminder', { path:':reminder_id' });
+    this.route('edit', { path:':reminder_id/edit' });
     this.route('new');
   });
 });

--- a/app/routes/reminders/edit.js
+++ b/app/routes/reminders/edit.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+
+  model(params) {
+    return this.get('store').find('reminder', params.reminder_id);
+  },
+
+  actions: {
+    editReminder(reminderForm) {
+      let stringDate = reminderForm.get('date');
+      reminderForm.set('title', reminderForm.get('title'));
+      if(stringDate) {
+        reminderForm.set('date', new Date(stringDate));
+      }
+      reminderForm.set('notes', reminderForm.get('notes'));
+      reminderForm.save().then((reminder) => {
+        this.transitionTo('reminders.reminder', reminder)
+      });
+    }
+  }
+});

--- a/app/routes/reminders/new.js
+++ b/app/routes/reminders/new.js
@@ -12,12 +12,12 @@ export default Ember.Route.extend({
       if(stringDate) {
         reminderForm.set('date', new Date(stringDate));
       } else {
-        reminderForm.set('date', new Date());        
+        reminderForm.set('date', new Date());
       }
       let reminderProps = reminderForm.getProperties('title', 'date', 'notes');
       let record = this.get('store').createRecord('reminder', reminderProps);
-      record.save().then(() => {
-        return this.transitionTo('reminders.new');
+      record.save().then((reminder) => {
+          this.transitionTo('reminders.reminder', reminder);
       });
     }
   }

--- a/app/templates/reminders/edit.hbs
+++ b/app/templates/reminders/edit.hbs
@@ -1,0 +1,16 @@
+<form class='spec-edit-reminder--form' {{action 'editReminder' model on='submit'}}>
+  <label>
+    Title
+    {{input class='spec-edit-title-input' value=model.title}}
+  </label>
+  <label>
+    Date
+    {{input type='date' class='spec-edit-date-input' value=model.date}}
+  </label>
+  <label>
+    Notes
+    {{textarea class='spec-edit-notes-input' value=model.notes}}
+  </label>
+  <button type='submit' class='spec-save-edit'>Submit</button>
+</form>
+{{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -2,6 +2,9 @@
   <h1 class="spec-reminder-title">{{model.title}}</h1>
   <p>{{model.date}}</p>
   <p>{{model.notes}}</p>
+  {{#link-to 'reminders.edit' model class='spec-edit-reminder-button' tagName='button'}}
+    Edit
+  {{/link-to}}
 </section>
 
 {{outlet}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -3,5 +3,6 @@ export default function() {
   this.post('/reminders');
   this.get('/reminders/:id');
   this.put('/reminders/:id');
+  this.patch('/reminders/:id');
   this.del('/reminders/:id');
 }

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -45,8 +45,24 @@ test('adds an individual reminder on form submit', function(assert) {
   click('.spec-submit-reminder');
 
   andThen(function() {
-    assert.equal(currentURL(), '/new');
+    assert.equal(currentURL(), '/6');
     assert.equal(find('.spec-reminder-item').length, 6, 'should show one additional reminder');
     assert.equal(find('.spec-reminder-item:last').text().trim(), 'Tom Cruise', 'should show new reminder title');
+  });
+});
+
+test('an edit content button that allows the user to edit that reminder, save it and goes back to that reminder after', function(assert) {
+
+  visit('/');
+  click('.spec-reminder-item:first');
+  click('.spec-edit-reminder-button');
+  fillIn('.spec-edit-title-input', 'Do Something');
+  fillIn('.spec-edit-date-input', '11/15/2018');
+  fillIn('.spec-edit-notes-input', 'Because I am bored');
+  click('.spec-save-edit');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/1');
+    assert.equal(find('.spec-reminder-item:first').text().trim(), 'Do Something', 'should show edited title');
   });
 });

--- a/tests/unit/routes/reminders/edit-test.js
+++ b/tests/unit/routes/reminders/edit-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:reminders/edit', 'Unit | Route | reminders/edit', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
## Purpose

_Add edit feature to individual reminders and information is saved.
https://github.com/turingschool-projects/1606-remember-6/issues/7_

## Approach

_This solves the issue that users weren't able to edit saved reminders.._

### Learning

_We referenced how the add new reminder route functioned and looked to replicate that functionality.  We utilized Ember docs to figure out how to transition between URLs and added a new action based off of a StackOverflow reference._

_http://stackoverflow.com/questions/21630062/how-to-set-value-for-input-field-and-have-it-update-on-submission-to-ember-js-ac_

_https://guides.emberjs.com/v2.8.0/routing/redirection/_

#### Blog Posts

### Open Questions and Pre-Merge TODOs

- [ ] Use Github checklists. When solved, check the box and explain the answer.

### Test coverage 

_Wrote a test to make sure that from the home page, a user can select a reminder and select the edit button.  After the edit button is selected all information can be updated and the user hits the save button to update the saved data._

### Merge Dependencies and Related Work

### Follow-up tasks

- [Issue #9 (Example)](https://github.com/turingschool-projects/1606-remember-6/issues/9)

### Screenshots

#### Before

https://camo.githubusercontent.com/00c7337338d53732d76b75b85db4b5eba2fb747f/687474703a2f2f672e7265636f726469742e636f2f4d6f386947534d4b756a2e676966

#### After

http://recordit.co/7RKSCOAotB