### PR TITLE
Feature revert - Closes #9

### DIFF
--- a/app/controllers/reminders/edit.js
+++ b/app/controllers/reminders/edit.js
@@ -14,5 +14,7 @@ export default Ember.Controller.extend({
       });
       return false;
     }
+
+    // revertReminder()
   }
 });

--- a/app/controllers/reminders/edit.js
+++ b/app/controllers/reminders/edit.js
@@ -10,11 +10,14 @@ export default Ember.Controller.extend({
       }
       editReminderForm.set('notes', editReminderForm.get('notes'));
       editReminderForm.save().then((reminder) => {
-        this.transitionToRoute('reminders.reminder', reminder)
+        this.transitionToRoute('reminders.reminder', reminder);
       });
       return false;
-    }
+    },
 
-    // revertReminder()
+    revertReminder(reminder) {
+      reminder.rollbackAttributes();
+      this.transitionToRoute('reminders.reminder', reminder);
+    }
   }
 });

--- a/app/controllers/reminders/edit.js
+++ b/app/controllers/reminders/edit.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    editReminder(editReminderForm) {
+      let stringDate = editReminderForm.get('date');
+      editReminderForm.set('title', editReminderForm.get('title'));
+      if(stringDate) {
+        editReminderForm.set('date', new Date(stringDate));
+      }
+      editReminderForm.set('notes', editReminderForm.get('notes'));
+      editReminderForm.save().then((reminder) => {
+        this.transitionToRoute('reminders.reminder', reminder)
+      });
+      return false;
+    }
+  }
+});

--- a/app/controllers/reminders/new.js
+++ b/app/controllers/reminders/new.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    createReminder(reminderForm) {
+      let stringDate = reminderForm.get('date');
+      if(stringDate) {
+        reminderForm.set('date', new Date(stringDate));
+      } else {
+        reminderForm.set('date', new Date());
+      }
+      let reminderProps = reminderForm.getProperties('title', 'date', 'notes');
+      let record = this.get('store').createRecord('reminder', reminderProps);
+      record.save().then((reminder) => {
+          this.transitionToRoute('reminders.reminder', reminder);
+      });
+      return false;
+    }
+  }
+});

--- a/app/router.js
+++ b/app/router.js
@@ -9,6 +9,7 @@ const Router = Ember.Router.extend({
 Router.map(function() {
   this.route('reminders', { path: '/' }, function() {
     this.route('reminder', { path:':reminder_id' });
+    this.route('edit', { path:':reminder_id/edit' });
     this.route('new');
   });
 });

--- a/app/routes/reminders/edit.js
+++ b/app/routes/reminders/edit.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+
+  model(params) {
+    return this.get('store').find('reminder', params.reminder_id);
+  },
+
+  actions: {
+    editReminder(reminderForm) {
+      let stringDate = reminderForm.get('date');
+      reminderForm.set('title', reminderForm.get('title'));
+      if(stringDate) {
+        reminderForm.set('date', new Date(stringDate));
+      }
+      reminderForm.set('notes', reminderForm.get('notes'));
+      reminderForm.save().then((reminder) => {
+        this.transitionTo('reminders.reminder', reminder)
+      });
+    }
+  }
+});

--- a/app/routes/reminders/edit.js
+++ b/app/routes/reminders/edit.js
@@ -5,18 +5,4 @@ export default Ember.Route.extend({
   model(params) {
     return this.get('store').findRecord('reminder', params.reminder_id);
   },
-
-  actions: {
-    editReminder(editReminderForm) {
-      let stringDate = editReminderForm.get('date');
-      editReminderForm.set('title', editReminderForm.get('title'));
-      if(stringDate) {
-        editReminderForm.set('date', new Date(stringDate));
-      }
-      editReminderForm.set('notes', editReminderForm.get('notes'));
-      editReminderForm.save().then((reminder) => {
-        this.transitionTo('reminders.reminder', reminder)
-      });
-    }
-  }
 });

--- a/app/routes/reminders/edit.js
+++ b/app/routes/reminders/edit.js
@@ -3,18 +3,18 @@ import Ember from 'ember';
 export default Ember.Route.extend({
 
   model(params) {
-    return this.get('store').find('reminder', params.reminder_id);
+    return this.get('store').findRecord('reminder', params.reminder_id);
   },
 
   actions: {
-    editReminder(reminderForm) {
-      let stringDate = reminderForm.get('date');
-      reminderForm.set('title', reminderForm.get('title'));
+    editReminder(editReminderForm) {
+      let stringDate = editReminderForm.get('date');
+      editReminderForm.set('title', editReminderForm.get('title'));
       if(stringDate) {
-        reminderForm.set('date', new Date(stringDate));
+        editReminderForm.set('date', new Date(stringDate));
       }
-      reminderForm.set('notes', reminderForm.get('notes'));
-      reminderForm.save().then((reminder) => {
+      editReminderForm.set('notes', editReminderForm.get('notes'));
+      editReminderForm.save().then((reminder) => {
         this.transitionTo('reminders.reminder', reminder)
       });
     }

--- a/app/routes/reminders/new.js
+++ b/app/routes/reminders/new.js
@@ -5,20 +5,4 @@ export default Ember.Route.extend({
   model() {
     return Ember.Object.create();
   },
-
-  actions: {
-    createReminder(reminderForm) {
-      let stringDate = reminderForm.get('date');
-      if(stringDate) {
-        reminderForm.set('date', new Date(stringDate));
-      } else {
-        reminderForm.set('date', new Date());
-      }
-      let reminderProps = reminderForm.getProperties('title', 'date', 'notes');
-      let record = this.get('store').createRecord('reminder', reminderProps);
-      record.save().then((reminder) => {
-          this.transitionTo('reminders.reminder', reminder);
-      });
-    }
-  }
 });

--- a/app/routes/reminders/new.js
+++ b/app/routes/reminders/new.js
@@ -12,12 +12,12 @@ export default Ember.Route.extend({
       if(stringDate) {
         reminderForm.set('date', new Date(stringDate));
       } else {
-        reminderForm.set('date', new Date());        
+        reminderForm.set('date', new Date());
       }
       let reminderProps = reminderForm.getProperties('title', 'date', 'notes');
       let record = this.get('store').createRecord('reminder', reminderProps);
-      record.save().then(() => {
-        return this.transitionTo('reminders.new');
+      record.save().then((reminder) => {
+          this.transitionTo('reminders.reminder', reminder);
       });
     }
   }

--- a/app/templates/components/reminder-form.hbs
+++ b/app/templates/components/reminder-form.hbs
@@ -12,4 +12,9 @@
     {{textarea class='spec-note-input' value=reminder.notes}}
   </label>
   <button type='submit' class='spec-submit-reminder'>Submit</button>
+  <button
+    class='spec-revert-button'
+    {{action 'revertReminder' on='click'}}
+    hidden={{unless reminder.hasDirtyAttributes 'true'}}
+  >Revert</button>
 </form>

--- a/app/templates/components/reminder-form.hbs
+++ b/app/templates/components/reminder-form.hbs
@@ -12,9 +12,5 @@
     {{textarea class='spec-note-input' value=reminder.notes}}
   </label>
   <button type='submit' class='spec-submit-reminder'>Submit</button>
-  <button
-    class='spec-revert-button'
-    {{action 'revertReminder' on='click'}}
-    hidden={{unless reminder.hasDirtyAttributes 'true'}}
-  >Revert</button>
+  {{yield}}
 </form>

--- a/app/templates/components/reminder-form.hbs
+++ b/app/templates/components/reminder-form.hbs
@@ -1,0 +1,15 @@
+<form>
+  <label>
+    Title
+    {{input class='spec-title-input' value=reminder.title}}
+  </label>
+  <label>
+    Date
+    {{input type='date' class='spec-date-input' value=reminder.date}}
+  </label>
+  <label>
+    Notes
+    {{textarea class='spec-note-input' value=reminder.notes}}
+  </label>
+  <button type='submit' class='spec-submit-reminder'>Submit</button>
+</form>

--- a/app/templates/reminders/edit.hbs
+++ b/app/templates/reminders/edit.hbs
@@ -1,0 +1,16 @@
+<form class='spec-edit-reminder--form' {{action 'editReminder' model on='submit'}}>
+  <label>
+    Title
+    {{input class='spec-edit-title-input' value=model.title}}
+  </label>
+  <label>
+    Date
+    {{input type='date' class='spec-edit-date-input' value=model.date}}
+  </label>
+  <label>
+    Notes
+    {{textarea class='spec-edit-notes-input' value=model.notes}}
+  </label>
+  <button type='submit' class='spec-save-edit'>Submit</button>
+</form>
+{{outlet}}

--- a/app/templates/reminders/edit.hbs
+++ b/app/templates/reminders/edit.hbs
@@ -4,6 +4,11 @@
   reminder=model
   submit=(action 'editReminder' model)
 }}
+<button
+  class='spec-revert-button'
+  {{action 'revertReminder' model on='click'}}
+  hidden={{unless reminder.hasDirtyAttributes 'true'}}
+>Revert</button>
 {{/reminder-form}}
 
 {{outlet}}

--- a/app/templates/reminders/edit.hbs
+++ b/app/templates/reminders/edit.hbs
@@ -1,4 +1,8 @@
-<form class='spec-edit-reminder--form' {{action 'editReminder' model on='submit'}}>
+
+{{#reminder-form class='spec-edit' reminder=model submit=(action 'editReminder' model)}}
+{{/reminder-form}}
+
+<!-- <form class='spec-edit-reminder--form' {{action 'editReminder' model on='submit'}}>
   <label>
     Title
     {{input class='spec-edit-title-input' value=model.title}}
@@ -12,5 +16,5 @@
     {{textarea class='spec-edit-notes-input' value=model.notes}}
   </label>
   <button type='submit' class='spec-save-edit'>Submit</button>
-</form>
+</form> -->
 {{outlet}}

--- a/app/templates/reminders/edit.hbs
+++ b/app/templates/reminders/edit.hbs
@@ -1,20 +1,9 @@
 
-{{#reminder-form class='spec-edit' reminder=model submit=(action 'editReminder' model)}}
+{{#reminder-form
+  class='spec-edit'
+  reminder=model
+  submit=(action 'editReminder' model)
+}}
 {{/reminder-form}}
 
-<!-- <form class='spec-edit-reminder--form' {{action 'editReminder' model on='submit'}}>
-  <label>
-    Title
-    {{input class='spec-edit-title-input' value=model.title}}
-  </label>
-  <label>
-    Date
-    {{input type='date' class='spec-edit-date-input' value=model.date}}
-  </label>
-  <label>
-    Notes
-    {{textarea class='spec-edit-notes-input' value=model.notes}}
-  </label>
-  <button type='submit' class='spec-save-edit'>Submit</button>
-</form> -->
 {{outlet}}

--- a/app/templates/reminders/edit.hbs
+++ b/app/templates/reminders/edit.hbs
@@ -7,7 +7,7 @@
 <button
   class='spec-revert-button'
   {{action 'revertReminder' model on='click'}}
-  hidden={{unless reminder.hasDirtyAttributes 'true'}}
+  hidden={{unless model.hasDirtyAttributes 'true'}}
 >Revert</button>
 {{/reminder-form}}
 

--- a/app/templates/reminders/new.hbs
+++ b/app/templates/reminders/new.hbs
@@ -1,18 +1,6 @@
 <h2>New Reminder</h2>
 
-<form class='spec-add-reminder--form' {{action 'createReminder' model on='submit'}}>
-  <label>
-    Title
-    {{input class='spec-new-title-input' value=model.title}}
-  </label>
-  <label>
-    Date
-    {{input type='date' class='spec-new-date-input' value=model.date}}
-  </label>
-  <label>
-    Notes
-    {{textarea class='spec-new-note-input' value=model.notes}}
-  </label>
-  <button type='submit' class='spec-submit-reminder'>Submit</button>
-</form>
+{{#reminder-form class='spec-add' reminder=model submit=(action 'createReminder' model)}}
+{{/reminder-form}}
+
 {{outlet}}

--- a/app/templates/reminders/new.hbs
+++ b/app/templates/reminders/new.hbs
@@ -1,6 +1,10 @@
 <h2>New Reminder</h2>
 
-{{#reminder-form class='spec-add' reminder=model submit=(action 'createReminder' model)}}
+{{#reminder-form
+  class='spec-add'
+  reminder=model
+  submit=(action 'createReminder' model)
+}}
 {{/reminder-form}}
 
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -2,6 +2,9 @@
   <h1 class="spec-reminder-title">{{model.title}}</h1>
   <p>{{model.date}}</p>
   <p>{{model.notes}}</p>
+  {{#link-to 'reminders.edit' model class='spec-edit-reminder-button' tagName='button'}}
+    Edit
+  {{/link-to}}
 </section>
 
 {{outlet}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -3,5 +3,6 @@ export default function() {
   this.post('/reminders');
   this.get('/reminders/:id');
   this.put('/reminders/:id');
+  this.patch('/reminders/:id');
   this.del('/reminders/:id');
 }

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -39,9 +39,9 @@ test('adds an individual reminder on form submit', function(assert) {
 
   visit('/');
   click('.spec-add-new-reminder');
-  fillIn('.spec-new-title-input', 'Tom Cruise');
-  fillIn('.spec-new-date-input', '12/11/2017');
-  fillIn('.spec-new-note-input', 'Star in every movie ever');
+  fillIn('.spec-add .spec-title-input', 'Tom Cruise');
+  fillIn('.spec-add .spec-date-input', '12/11/2017');
+  fillIn('.spec-add .spec-note-input', 'Star in every movie ever');
   click('.spec-submit-reminder');
 
   andThen(function() {
@@ -56,10 +56,10 @@ test('an edit content button that allows the user to edit that reminder, save it
   visit('/');
   click('.spec-reminder-item:first');
   click('.spec-edit-reminder-button');
-  fillIn('.spec-edit-title-input', 'Do Something');
-  fillIn('.spec-edit-date-input', '11/15/2018');
-  fillIn('.spec-edit-notes-input', 'Because I am bored');
-  click('.spec-save-edit');
+  fillIn('.spec-edit .spec-title-input', 'Do Something');
+  fillIn('.spec-edit .spec-date-input', '11/15/2018');
+  fillIn('.spec-edit .spec-note-input', 'Because I am bored');
+  click('.spec-submit-reminder');
 
   andThen(function() {
     assert.equal(currentURL(), '/1');

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -45,8 +45,24 @@ test('adds an individual reminder on form submit', function(assert) {
   click('.spec-submit-reminder');
 
   andThen(function() {
-    assert.equal(currentURL(), '/new');
+    assert.equal(currentURL(), '/6');
     assert.equal(find('.spec-reminder-item').length, 6, 'should show one additional reminder');
     assert.equal(find('.spec-reminder-item:last').text().trim(), 'Tom Cruise', 'should show new reminder title');
+  });
+});
+
+test('an edit content button that allows the user to edit that reminder, save it and goes back to that reminder after', function(assert) {
+
+  visit('/');
+  click('.spec-reminder-item:first');
+  click('.spec-edit-reminder-button');
+  fillIn('.spec-edit-title-input', 'Do Something');
+  fillIn('.spec-edit-date-input', '11/15/2018');
+  fillIn('.spec-edit-notes-input', 'Because I am bored');
+  click('.spec-save-edit');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/1');
+    assert.equal(find('.spec-reminder-item:first').text().trim(), 'Do Something', 'should show edited title');
   });
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -66,3 +66,20 @@ test('an edit content button that allows the user to edit that reminder, save it
     assert.equal(find('.spec-reminder-item:first').text().trim(), 'Do Something', 'should show edited title');
   });
 });
+
+test('is able to revert to old state while editing', function(assert) {
+
+  visit('/');
+  click('.spec-reminder-item:first');
+  click('.spec-edit-reminder-button');
+  fillIn('.spec-edit .spec-title-input', 'Do Something');
+  click('.spec-submit-reminder');
+  click('.spec-edit-reminder-button');
+  fillIn('.spec-edit .spec-title-input', 'Do Something Else');
+  click('.spec-revert-button');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/1');
+    assert.equal(find('.spec-reminder-item:first').text().trim(), 'Do Something', 'should show edited title');
+  });
+});

--- a/tests/unit/controllers/reminders/edit-test.js
+++ b/tests/unit/controllers/reminders/edit-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:reminders/edit', 'Unit | Controller | reminders/edit', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/controllers/reminders/new-test.js
+++ b/tests/unit/controllers/reminders/new-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:reminders/new', 'Unit | Controller | reminders/new', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/routes/reminders/edit-test.js
+++ b/tests/unit/routes/reminders/edit-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:reminders/edit', 'Unit | Route | reminders/edit', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
@stevekinney @brittanystoroz @martensonbj 

## Purpose

_We've added a feature that allows users to revert back to their previous reminder's information while editing._

## Approach

_If a user was editing their reminder they wouldn't be able to go back to the original state of their reminder._

### Learning

_We started this process off by looking over what dirty attributes are and used the Ember Dev Tools to see how that flag changed once we started editing a field. Next, we researched the rollback feature Ember allows you to use. After reading some docs we implemented the button & used the hidden attribute on the button to only show it when the attributes were dirty. We then added the revertReminder action to our edit controller, which is called once the Revert button is clicked. Finally, in order to avoid confusion between the submit button & the revert button we added the {yield} to our overall form component._

_http://emberjs.com/api/data/classes/DS.Model.html#property_hasDirtyAttributes_
_http://emberjs.com/api/data/classes/DS.Model.html#method_rollbackAttributes_

#### Blog Posts

### Open Questions and Pre-Merge TODOs

- [ ] Use Github checklists. When solved, check the box and explain the answer.

### Test coverage 

_We wrote a test for this feature that edits one of the pre-populated reminders and sets it to a specific title. We submit that edit & then begin editing that reminder again, only this time clicking on the revert button. We assert that the original title should be present rather than the dirty one._

### Merge Dependencies and Related Work

_This PR relies on issue #11 being closed before this is merged in._

### Follow-up tasks

- [Issue #12 ] & [Issue #10 ]

### Screenshots

#### Before

https://camo.githubusercontent.com/00c7337338d53732d76b75b85db4b5eba2fb747f/687474703a2f2f672e7265636f726469742e636f2f4d6f386947534d4b756a2e676966

#### After

http://recordit.co/pd28T2pEoh